### PR TITLE
feat: Persist mobile panel states

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -10,6 +10,7 @@ import Aura from "@primeuix/themes/aura";
 import { definePreset } from "@primeuix/themes";
 import { useThemeStore, Theme } from "@/stores/themeStore";
 import { initLists } from "./stores/listStore";
+import { initPanels } from "./stores/panelStore";
 
 import Accordion from "primevue/accordion";
 import AccordionContent from "primevue/accordioncontent";
@@ -194,8 +195,9 @@ if (savedTheme === "dark" || (!savedTheme && prefersDarkMode)) {
 const savedGlassEffects = localStorage.getItem("mobileGlassEffects");
 themeStore.setGlassEffects(savedGlassEffects !== "false", false);
 
-// Initialize lists
+// Initialize lists and mobile panel states
 initLists();
+initPanels();
 
 registerSW({
   immediate: true

--- a/src/stores/panelStore.ts
+++ b/src/stores/panelStore.ts
@@ -1,14 +1,48 @@
 import { ref } from "vue";
+import type { PanelState } from "@/types/types";
 
 const showStructure = ref(true);
 const showRelated = ref(false);
 
 const setStructure = (open: boolean) => {
   showStructure.value = open;
+  savePanelState();
 };
 
 const setRelated = (open: boolean) => {
   showRelated.value = open;
+  savePanelState();
+};
+
+const savePanelState = () => {
+  const state: PanelState = {
+    structure: showStructure.value,
+    related: showRelated.value
+  };
+
+  localStorage.setItem("mobilePanelStates", JSON.stringify(state));
+};
+
+export const initPanels = () => {
+  const savedPanels = localStorage.getItem("mobilePanelStates");
+
+  if (!savedPanels) {
+    return;
+  }
+
+  try {
+    const parsed = JSON.parse(savedPanels) as Partial<PanelState>;
+    if (typeof parsed.structure === "boolean") {
+      showStructure.value = parsed.structure;
+    }
+    if (typeof parsed.related === "boolean") {
+      showRelated.value = parsed.related;
+    }
+  }
+  catch {
+    console.warn("Failed to parse panel states from localStorage, using defaults.");
+    localStorage.removeItem("mobilePanelStates");
+  }
 };
 
 export const usePanelStore = () => {

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -54,3 +54,8 @@ export type AppearsInList = {
   mainlistValue: string;
   sublistValue: string;
 }
+
+export type PanelState = {
+  structure: boolean;
+  related: boolean;
+};


### PR DESCRIPTION
Changelog:
- Save panel states for mobile in localstorage
- Upon opening the application, panel states are read and initialized from localstorage